### PR TITLE
Fixed case typo

### DIFF
--- a/src/android/Connectivity.java
+++ b/src/android/Connectivity.java
@@ -151,7 +151,7 @@ public class Connectivity {
     }
   }
 
-  public void observeRemoteHostname(String hostName) {
+  public void observeRemoteHostName(String hostName) {
     this.hostName = hostName;
     isCheckingHostNameReachability = true;
     startAllObservers();


### PR DESCRIPTION
observeRemoteHostname -> observeRemoteHostName

connectivity.js refers to it via observeRemoteHostName
