### PR TITLE
events -> EVENTS in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To start monitoring connectivity, place the following code in your onDeviceReady
       
       document.removeEventListener('deviceready', onDeviceReady, false);
       
-      document.addEventListener(connectivity.events.onReachabilityChanged, onReachabilityChanged, false)
+      document.addEventListener(connectivity.EVENTS.onReachabilityChanged, onReachabilityChanged, false)
       connectivity.observeRemoteHostName(myHostToObserve);
     }
     


### PR DESCRIPTION
I am new to this cordova plugin, but I am assuming the name of the connectivity property is EVENTS with capital letters?

Further below, under heading Events, it is referred to as "EVENTS". And running the example with 'connectivity.events' gives undefined error.
